### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+autocutsel (0.10.1-2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on dpkg-dev.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 02 Feb 2022 09:36:32 -0000
+
 autocutsel (0.10.1-1) unstable; urgency=medium
 
   [ Debian Janitor ]

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: Elmar S. Heeb <elmar@heebs.ch>
 Uploaders: Axel Beckert <abe@debian.org>
 Build-Depends: debhelper-compat (= 13),
-               dpkg-dev (>= 1.16.1~),
                libxaw7-dev
 Standards-Version: 4.6.0
 Homepage: https://www.nongnu.org/autocutsel/


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/autocutsel/fe7601ad-b1f4-4f8e-904d-1b04d419658c.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/fe7601ad-b1f4-4f8e-904d-1b04d419658c/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/fe7601ad-b1f4-4f8e-904d-1b04d419658c/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/fe7601ad-b1f4-4f8e-904d-1b04d419658c/diffoscope)).
